### PR TITLE
Updated CohortIncidence refs and added minCellCount handling

### DIFF
--- a/Main.R
+++ b/Main.R
@@ -100,12 +100,12 @@ execute <- function(jobContext) {
   # apply minCellCount to  executeResults
   minCellCount <- jobContext$moduleExecutionSettings$minCellCount;
   if (minCellCount > 0) {
-    executeResults <- enforceMinCellValue(executeResults, "persons_at_risk_pe", minCellCount)
-    executeResults <- enforceMinCellValue(executeResults, "persons_at_risk", minCellCount)
-    executeResults <- enforceMinCellValue(executeResults, "person_outcomes_pe", minCellCount)
-    executeResults <- enforceMinCellValue(executeResults, "person_outcomes", minCellCount)
-    executeResults <- enforceMinCellValue(executeResults, "outcomes_pe", minCellCount)
-    executeResults <- enforceMinCellValue(executeResults, "outcomes", minCellCount)
+    executeResults <- enforceMinCellValue(executeResults, "PERSONS_AT_RISK_PE", minCellCount)
+    executeResults <- enforceMinCellValue(executeResults, "PERSONS_AT_RISK", minCellCount)
+    executeResults <- enforceMinCellValue(executeResults, "PERSON_OUTCOMES_PE", minCellCount)
+    executeResults <- enforceMinCellValue(executeResults, "PERSON_OUTCOMES", minCellCount)
+    executeResults <- enforceMinCellValue(executeResults, "OUTCOMES_PE", minCellCount)
+    executeResults <- enforceMinCellValue(executeResults, "OUTCOMES", minCellCount)
   }
 
   readr::write_csv(executeResults, file.path(exportFolder,"incidence_summary.csv")) # this will be renamed later

--- a/MetaData.json
+++ b/MetaData.json
@@ -1,6 +1,6 @@
 {
   "Name": "CohortIncidenceModule",
-  "Version": "0.0.6",
+  "Version": "0.0.7",
   "Dependencies": ["CohortGeneratorModule"],
   "TablePrefix": "ci_"
 }

--- a/SettingsFunctions.R
+++ b/SettingsFunctions.R
@@ -7,7 +7,7 @@ createCohortIncidenceModuleSpecifications <- function(irDesign = NULL) {
   }
 
   specifications <- list(module = "CohortIncidenceModule",
-                         version = "0.0.6",
+                         version = "0.0.7",
                          remoteRepo = "github.com",
                          remoteUsername = "ohdsi",
                          settings = analysis)

--- a/renv.lock
+++ b/renv.lock
@@ -22,13 +22,13 @@
     },
     "CohortIncidence": {
       "Package": "CohortIncidence",
-      "Version": "3.1.2",
+      "Version": "3.1.3",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteRepo": "CohortIncidence",
       "RemoteUsername": "ohdsi",
-      "RemoteRef": "v3.1.2",
+      "RemoteRef": "v3.1.3",
       "Requirements": []
     },
     "DBI": {


### PR DESCRIPTION
The new reference guards against sql injection and truncates names to 255 chars.
The minCellCount handling was put into execute() and leverages the approach used in other study packages.
